### PR TITLE
Add section on errors, warnings, and messages

### DIFF
--- a/02-getting-started.Rmd
+++ b/02-getting-started.Rmd
@@ -132,8 +132,21 @@ Learning to code/program is very much like learning a foreign language, it can b
 * **Take the "copy/paste/tweak" approach**: Especially when learning your first programming language, it is often much easier to taking existing code that you know works and modify it to suit your ends, rather than trying to write new code from scratch. We call this the *copy/paste/tweak* approach. So early on, we suggest not trying to code from scratch, but please take the code we provide throughout this book and play around with it!
 * **Practice is key**:  Just as the only solution to improving your foreign language skills is practice, so also the only way to get better at R is through practice. Don't worry however, we'll give you plenty of opportunities to practice!
 
+### Errors, warnings, and messages
 
+One slightly confusing part of R is how it reports errors, warnings, and messages. The default theme in RStudio colors errors, warnings, and messages in red, which makes them seem like you did something wrong. However, seeing red text in the console *is not always bad.*
 
+R will show red text in the console in three different situations:
+
+- **Errors**: When the red text is a legitimate error, it will be prefaced with "Error in…" and try to explain what went wrong. Generally when there's an error, the code will not run. For instance, if you see `Error in ggplot(...) : could not find function "ggplot"`, it means that the `ggplot()` function is not accessible because the package was not loaded with `library(ggplot2)`. 
+- **Warnings**: When the red text is a warning, it will be prefaced with "Warning:" and try to explain why there's a warning. Generally your code will still work, but with some caveats. For instance, if you plot a scatterplot and one of the rows in your data frame is missing a value, you will see this warning: `Warning: Removed 1 rows containing missing values (geom_point)`. R will still make the scatterplot with all the remaining values, but it's warning you that one of the points isn't there.
+- **Messages**: When the red text doesn't start with either "Error" or "Warning", it's *just a friendly message*. You'll see these messages when you load some packages (like `library(tidyverse)`, which tells you that it is loading several other packages), or when you read data from CSV files with `read_csv()`. These are helpful diagnostic messages and they don't stop your code from working.
+
+Remember, when you see red text in the console, *don't panic*. It doesn't necessarily mean anything is wrong. 
+
+- If the text starts with "Error", figure out what's causing it.
+- If the text starts with "Warning", figure out if it's something to worry about. For instance, if you get a warning about missing values in a scatterplot and you know there are missing values, you're fine. If that's surprising, look at your data and see what's missing.
+- Otherwise the text is just a message. Read it, wave back at R, and thank it for talking to you.
 
 
 ---


### PR DESCRIPTION
Added a section explaining the difference between errors, warnings, and messages. Many of my students assumed something catastrophic happened when they loaded tidyverse or read a CSV for the first time, which definitely isn't the case. To reassure them, I sent them [a version of this](https://twitter.com/andrewheiss/status/1040658660056227840) via e-mail. Hopefully this is helpful for future readers.