### PR TITLE
Update 03-visualization.Rmd

### DIFF
--- a/03-visualization.Rmd
+++ b/03-visualization.Rmd
@@ -568,7 +568,7 @@ We can adjust characteristics of the bins in one of *two* ways:
 1. By adjusting the number of bins via the `bins` argument
 1. By adjusting the width of the bins via the `binwidth` argument
 
-First, we have the power to specify how many bins we would like to put the data into as an argument in the `geom_histogram()` function.  By default, this is chosen to be 30 somewhat arbitrarily; we have received a warning above our plot that this was done.
+First, we have the power to specify how many bins we would like to put the data into as an argument in the `geom_histogram()` function.  By default, this is chosen to be 30 somewhat arbitrarily; the warning we received told us  that this value was used.
 
 ```{r fig.cap=paste(hist_title, "- 60 Bins")}
 ggplot(data = weather, mapping = aes(x = temp)) +


### PR DESCRIPTION
Modified description of bin width options to clarify:  'By default, this is chosen to be 30 somewhat arbitrarily; the warning we received told us  that this value was used.'