### PR TITLE
Update 05-wrangling.Rmd

### DIFF
--- a/05-wrangling.Rmd
+++ b/05-wrangling.Rmd
@@ -1087,3 +1087,5 @@ We will focus only on the `dplyr` functions in this book, but you are encouraged
 ### Script of R code
 
 An R script file of all R code used in this chapter is available [here](scripts/05-wrangling.R).
+
+DB: (not a suggested change so much as a comment)


### PR DESCRIPTION
Not really a pull request, so much as a comment.
In section ## Summarize variables using summarize {#summarize}: I always find it frustrating that there does not seem an easy way to include the N in the created summary, taking into account na.rm. I.e. we do want to know the N that was used for the mean and SD. Is there a way to do that? It just seems odd not to show it, as it is a key variable that influences how you interpret mean and SD, and can be useful for flagging up existence of missing data.