### PR TITLE
Fix build failure if {knitr} not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Welcome to the GitHub repository page for **Statistical Inference via Data Scien
 
 ## Contents of this Repository
 
-ModernDive is built using RStudio's [`bookdown`](https://www.rstudio.com/resources/webinars/introducing-bookdown/) package; for more information on how to use `bookdown` see [bookdown.org](https://bookdown.org/).
+ModernDive is built using RStudio's [`bookdown`](https://www.rstudio.com/resources/webinars/introducing-bookdown/) package; for more information on how to use `bookdown` see [bookdown.org](https://bookdown.org/). If you'd like to build the book on your own, please make sure to first install the `bookdown` package via `install.packages("bookdown")`.
 
 * The `bookdown` source code for the development version of ModernDive is above, the output of which can be previewed at [moderndive.netlify.com](https://moderndive.netlify.com) which is based on the outputted HTML files in the `docs/` folder.
 * The `bookdown` source code for all [previously released versions](https://moderndive.com/index.html#about-book) of ModernDive, including the latest version available at [ModernDive.com](https://moderndive.com/), is accessible on the [Releases](https://github.com/moderndive/moderndive_book/releases) page.

--- a/index.Rmd
+++ b/index.Rmd
@@ -36,6 +36,10 @@ date <- format(Sys.time(), '%B %d, %Y')
 latest_release_version <- "1.0.0"
 latest_release_date <- "November 25, 2019"
 
+if(!"knitr" %in% installed.packages()){
+  install.packages("knitr")
+}
+
 # Set output options
 if(knitr:::is_html_output())
   options(width = 80)


### PR DESCRIPTION
I also added a note to the README to make sure to install {bookdown} first since I don't think we can have that automatically happen if someone presses the Build button in RStudio.