### PR TITLE
Update names_transform in 04-tidy.Rmd

### DIFF
--- a/04-tidy.Rmd
+++ b/04-tidy.Rmd
@@ -435,7 +435,7 @@ guat_dem_tidy <- guat_dem %>%
   pivot_longer(names_to = "year", 
                values_to = "democracy_score", 
                cols = -country,
-               names_ptypes = list(year = integer())) 
+               names_transform = list(year = as.integer)) 
 guat_dem_tidy
 ```
 
@@ -444,7 +444,7 @@ We set the arguments to `pivot_longer()` as follows:
 1. `names_to` is the name of the variable in the new "tidy" data frame that will contain the *column names* of the original data. Observe how we set `names_to = "year"`.  In the resulting `guat_dem_tidy`, the column `year` contains the years where Guatemala's democracy scores were measured.
 1. `values_to` is the name of the variable in the new "tidy" data frame that will contain the *values* of the original data. Observe how we set `values_to = "democracy_score"`. In the resulting `guat_dem_tidy` the column `democracy_score` contains the 1 $\times$ 9 = 9 democracy scores as numeric values.
 1. The third argument is the columns you either want to or don't want to "tidy." Observe how we set this to `cols = -country` indicating that we don't want to "tidy" the `country` variable in `guat_dem` and rather only variables `1952` through `1992`. 
-1. The last argument of `names_ptypes` tells R what type of variable `year` should be set to. Without specifying that it is an `integer` as we've done here, `pivot_longer()` will set it to be a character value by default.
+1. The last argument of `names_transform` tells R what type of variable `year` should be set to. Without specifying that it is an `integer` as we've done here, `pivot_longer()` will set it to be a character value by default.
 
 We can now create the time-series plot in Figure \@ref(fig:guat-dem-tidy) to visualize how democracy scores in Guatemala have changed from 1952 to 1992 using a \index{ggplot2!geom\_line()} `geom_line()`. Furthermore, we'll use the `labs()` function in the `ggplot2` package to add informative labels to all the `aes()`thetic attributes of our plot, in this case the `x` and `y` positions.
 
@@ -454,7 +454,7 @@ ggplot(guat_dem_tidy, aes(x = year, y = democracy_score)) +
   labs(x = "Year", y = "Democracy Score")
 ```
 
-Note that if we forgot to include the `names_ptypes` argument specifying that `year` was not of character format, we would have gotten an error here since `geom_line()` wouldn't have known how to sort the character values in `year` in the right order. 
+Note that if we forgot to include the `names_transform` argument specifying that `year` was not of character format, we would have gotten an error here since `geom_line()` wouldn't have known how to sort the character values in `year` in the right order. 
 
 
 ```{block lc-tidying, type='learncheck', purl=FALSE}

--- a/04-tidy.Rmd
+++ b/04-tidy.Rmd
@@ -439,7 +439,7 @@ guat_dem_tidy <- guat_dem %>%
 guat_dem_tidy
 ```
 
-We set the arguments to `pivot_longer()` as follows:
+(Note this code differs slightly from our print edition due to an update of the `tidyr` package to version 1.1.0.) We set the arguments to `pivot_longer()` as follows:
 
 1. `names_to` is the name of the variable in the new "tidy" data frame that will contain the *column names* of the original data. Observe how we set `names_to = "year"`.  In the resulting `guat_dem_tidy`, the column `year` contains the years where Guatemala's democracy scores were measured.
 1. `values_to` is the name of the variable in the new "tidy" data frame that will contain the *values* of the original data. Observe how we set `values_to = "democracy_score"`. In the resulting `guat_dem_tidy` the column `democracy_score` contains the 1 $\times$ 9 = 9 democracy scores as numeric values.


### PR DESCRIPTION
The use of argument `names_ptypes` in `pivot_longer()` gives error `Can't convert <character> to <integer>` with `tidyr 1.1.0`.  Replaced with argument `names_transform` to avoid the error.