### PR TITLE
Typo fixes in preface

### DIFF
--- a/00-preface.Rmd
+++ b/00-preface.Rmd
@@ -6,7 +6,7 @@
 `r include_image("images/logos/Rlogo.png", html_opts = "height=100px", latex_opts = "height=10%")`        \hfill &emsp; &emsp; &emsp; `r include_image("images/logos/RStudio-Logo-Blue-Gradient.png", html_opts = "height=100px", latex_opts = "height=10%")`
 </center>
 
-**Help! I'm new to R and RStudio and I need to learn about them! However, I'm completely new to coding! What do I do?** 
+**Help! I'm completely new to coding and I need to learn R and RStudio! What do I do?** 
 
 \vspace{0.1in}
 
@@ -16,9 +16,9 @@
 <img src="images/logos/RStudio-Logo-Blue-Gradient.png" style="height: 150px;"/>
 -->
 
-If you're asking yourself this question, then you've come to the right place! Start with the "Introduction for students" section. 
+If you're asking yourself this question, then you've come to the right place! Start with the "Introduction for students" section.  
 
-* *Are you an instructor hoping to use this book in your courses? We recommend you first read the "Introduction for students" section first. Then, read the "Introduction for instructors" section for more information on how to teach with this book.*
+* *Are you an instructor hoping to use this book in your courses? We recommend reading the "Introduction for students" section first. Then, read the "Introduction for instructors" section for more information on how to teach with this book.*
 * *Are you looking to connect with and contribute to* ModernDive*? Then, read the "Connect and contribute" section for information on how.*
 * *Are you curious about the publishing of this book? Then, read the "About this book" section for more information on the open-source technology, in particular R Markdown and the bookdown package.*
 


### PR DESCRIPTION
- Clean up the "Help!" intro line.
- Remove redundant "first" in first bullet below "Help!" intro line.