### PR TITLE
Extending solution of LC8.5

### DIFF
--- a/94-appendixD.Rmd
+++ b/94-appendixD.Rmd
@@ -1383,6 +1383,11 @@ percentile_ci <- bootstrap_distribution %>%
 percentile_ci
 ```
 
+The standard-error method is not appropriate, because the bootstrap distribution is not bell-shaped:
+
+```{r}
+visualize(bootstrap_distribution)
+```
 
 
 ***


### PR DESCRIPTION
The second part of LC8.5 (“if appropriate, then use the standard-error method.”) is not mentioned in the solution. This PR adds a short (and hopefully correct) explanation to this part of LC8.5. If you have any suggestions, feel free to edit it to your liking.