### PR TITLE
Several fixes

### DIFF
--- a/05-regression.Rmd
+++ b/05-regression.Rmd
@@ -1103,7 +1103,7 @@ The `residual` column is simply $y - \widehat{y}$ = `lifeExp - lifeExp_hat`. The
 
 
 
-## Related topics
+## Related topics {#reg-related-topics}
 
 ### Correlation is not necessarily causation {#correlation-is-not-causation}
 

--- a/06-multiple-regression.Rmd
+++ b/06-multiple-regression.Rmd
@@ -957,7 +957,7 @@ regression_points %>%
 
 
 
-## Related topics
+## Related topics {#mult-reg-related-topics}
 
 ### Model selection {#model-selection}
 

--- a/08-confidence-intervals.Rmd
+++ b/08-confidence-intervals.Rmd
@@ -565,11 +565,11 @@ percentile_ci <- virtual_resampled_means %>%
   get_ci(level = 0.95, type = "percentile")
 ```
 
-One method to construct a confidence interval is to use the middle 95% of values of the bootstrap distribution. We can do this by computing the 2.5th and 97.5th percentiles, which are `r percentile_ci[["2.5%"]]` and `r percentile_ci[["97.5%"]]`, respectively. This is known as the *percentile method* for constructing confidence intervals. 
+One method to construct a confidence interval is to use the middle 95% of values of the bootstrap distribution. We can do this by computing the 2.5th and 97.5th percentiles, which are `r percentile_ci[["lower_ci"]]` and `r percentile_ci[["upper_ci"]]`, respectively. This is known as the *percentile method* for constructing confidence intervals. 
 
 For now, let's focus only on the concepts behind a percentile method constructed confidence interval; we'll show you the code that computes these values in the next section.
 
-Let's mark these percentiles on the bootstrap distribution with vertical lines in Figure \@ref(fig:percentile-method). About 95% of the `mean_year` variable values in `virtual_resampled_means` fall between `r percentile_ci[["2.5%"]]` and `r percentile_ci[["97.5%"]]`, with 2.5% to the left of the leftmost line and 2.5% to the right of the rightmost line. 
+Let's mark these percentiles on the bootstrap distribution with vertical lines in Figure \@ref(fig:percentile-method). About 95% of the `mean_year` variable values in `virtual_resampled_means` fall between `r percentile_ci[["lower_ci"]]` and `r percentile_ci[["upper_ci"]]`, with 2.5% to the left of the leftmost line and 2.5% to the right of the rightmost line. 
 
 (ref:perc-method) Percentile method 95% confidence interval. Interval endpoints marked by vertical lines.
 
@@ -638,7 +638,7 @@ ggplot(virtual_resampled_means, aes(x = mean_year)) +
   geom_vline(xintercept = standard_error_ci[[1, 2]], linetype = "dashed", size = 1)
 ```
 
-We see that both methods produce nearly identical 95% confidence intervals for $\mu$ with the percentile method yielding $(`r round(percentile_ci[["2.5%"]], 2)`, `r round(percentile_ci[["97.5%"]], 2)`)$ while the standard error method produces $(`r round(standard_error_ci[["lower"]], 2)`, `r round(standard_error_ci[["upper"]],2)`)$. However, recall that we can only use the standard error rule when the bootstrap distribution is roughly normally shaped. 
+We see that both methods produce nearly identical 95% confidence intervals for $\mu$ with the percentile method yielding $(`r round(percentile_ci[["lower_ci"]], 2)`, `r round(percentile_ci[["upper_ci"]], 2)`)$ while the standard error method produces $(`r round(standard_error_ci[["lower_ci"]], 2)`, `r round(standard_error_ci[["upper_ci"]],2)`)$. However, recall that we can only use the standard error rule when the bootstrap distribution is roughly normally shaped. 
 
 Now that we've introduced the concept of confidence intervals and laid out the intuition behind two methods for constructing them, let's explore the code that allows us to construct them. 
 
@@ -924,7 +924,7 @@ percentile_ci <- bootstrap_distribution %>%
 percentile_ci
 ```
 
-Alternatively, we can visualize the interval (`r percentile_ci[["2.5%"]] %>% round(2)`, `r percentile_ci[["97.5%"]] %>% round(2)`) by piping the `bootstrap_distribution` data frame into the `visualize()` function and adding a `shade_confidence_interval()` \index{infer!shade\_confidence\_interval()} layer. We set the `endpoints` argument to be `percentile_ci`.
+Alternatively, we can visualize the interval (`r percentile_ci[["lower_ci"]] %>% round(2)`, `r percentile_ci[["upper_ci"]] %>% round(2)`) by piping the `bootstrap_distribution` data frame into the `visualize()` function and adding a `shade_confidence_interval()` \index{infer!shade\_confidence\_interval()} layer. We set the `endpoints` argument to be `percentile_ci`.
 
 ```{r eval=FALSE}
 visualize(bootstrap_distribution) + 
@@ -976,7 +976,7 @@ standard_error_ci
 ```
 
 
-If we would like to visualize the interval (`r standard_error_ci[["lower"]] %>% round(2)`, `r standard_error_ci[["upper"]] %>% round(2)`), we can once again pipe the `bootstrap_distribution` data frame into the `visualize()` function and add a `shade_confidence_interval()` layer to our plot. We set the `endpoints` argument to be `standard_error_ci`. The resulting standard-error method based on a 95% confidence interval for $\mu$ can be seen in Figure \@ref(fig:se-ci-viz).
+If we would like to visualize the interval (`r standard_error_ci[["lower_ci"]] %>% round(2)`, `r standard_error_ci[["upper_ci"]] %>% round(2)`), we can once again pipe the `bootstrap_distribution` data frame into the `visualize()` function and add a `shade_confidence_interval()` layer to our plot. We set the `endpoints` argument to be `standard_error_ci`. The resulting standard-error method based on a 95% confidence interval for $\mu$ can be seen in Figure \@ref(fig:se-ci-viz).
 
 (ref:se-viz) Standard-error-method 95% confidence interval.
 
@@ -1005,8 +1005,8 @@ if (is_html_output()) {
 
 As noted in Section \@ref(ci-build-up), both methods produce similar confidence intervals:
 
-* Percentile method: (`r percentile_ci[["2.5%"]] %>% round(2)`, `r percentile_ci[["97.5%"]] %>% round(2)`)
-* Standard error method: (`r standard_error_ci[["lower"]] %>% round(2)`, `r standard_error_ci[["upper"]] %>% round(2)`)
+* Percentile method: (`r percentile_ci[["lower_ci"]] %>% round(2)`, `r percentile_ci[["upper_ci"]] %>% round(2)`)
+* Standard error method: (`r standard_error_ci[["lower_ci"]] %>% round(2)`, `r standard_error_ci[["upper_ci"]] %>% round(2)`)
 
 ```{block, type="learncheck", purl=FALSE}
 \vspace{-0.15in}
@@ -1029,7 +1029,7 @@ As noted in Section \@ref(ci-build-up), both methods produce similar confidence 
 
 Now that we've shown you how to construct confidence intervals using a sample drawn from a population, let's now focus on how to interpret their effectiveness. The effectiveness of a confidence interval is judged by whether or not it contains the true value of the population parameter. Going back to our fishing analogy in Section \@ref(ci-build-up), this is like asking, "Did our net capture the fish?".
 
-So, for example, does our percentile-based confidence interval of (`r percentile_ci[["2.5%"]] %>% round(2)`, `r percentile_ci[["97.5%"]] %>% round(2)`) "capture" the true mean year $\mu$ of *all* US pennies? Alas, we'll never know, because we don't know what the true value of $\mu$ is. After all, we're sampling to estimate it!
+So, for example, does our percentile-based confidence interval of (`r percentile_ci[["lower_ci"]] %>% round(2)`, `r percentile_ci[["upper_ci"]] %>% round(2)`) "capture" the true mean year $\mu$ of *all* US pennies? Alas, we'll never know, because we don't know what the true value of $\mu$ is. After all, we're sampling to estimate it!
 
 In order to interpret a confidence interval's effectiveness, we need to *know* what the value of the population parameter is. That way we can say whether or not a confidence interval "captured" this value. 
 
@@ -1397,7 +1397,7 @@ This is what we observed in Figure \@ref(fig:reliable-percentile). Our confidenc
 
 A common but incorrect interpretation is: "There is a 95% probability that the confidence interval contains $p$."  Looking at Figure \@ref(fig:reliable-percentile), each of the confidence intervals either does or doesn't contain $p$. In other words, the probability is either a 1 or a 0. 
 
-So if the 95% confidence level only relates to the reliability of the confidence interval construction procedure and not to a given confidence interval itself, what insight can be derived from a given confidence interval? For example, going back to the pennies example, we found that the percentile method 95% confidence interval for $\mu$ was (`r percentile_ci[["2.5%"]] %>% round(2)`, `r percentile_ci[["97.5%"]] %>% round(2)`), whereas the standard error method 95% confidence interval was (`r standard_error_ci[["lower"]] %>% round(2)`, `r standard_error_ci[["upper"]] %>% round(2)`). What can be said about these two intervals?
+So if the 95% confidence level only relates to the reliability of the confidence interval construction procedure and not to a given confidence interval itself, what insight can be derived from a given confidence interval? For example, going back to the pennies example, we found that the percentile method 95% confidence interval for $\mu$ was (`r percentile_ci[["lower_ci"]] %>% round(2)`, `r percentile_ci[["upper_ci"]] %>% round(2)`), whereas the standard error method 95% confidence interval was (`r standard_error_ci[["lower_ci"]] %>% round(2)`, `r standard_error_ci[["upper_ci"]] %>% round(2)`). What can be said about these two intervals?
 
 Loosely speaking, we can think of these intervals as our "best guess" of a plausible range of values for the mean year $\mu$ of *all* US pennies. For the rest of this book, we'll use the following shorthand summary of the precise interpretation. 
 
@@ -1405,7 +1405,7 @@ Loosely speaking, we can think of these intervals as our "best guess" of a plaus
 
 We use quotation marks around "confident" to emphasize that while 95% relates to the reliability of our confidence interval construction procedure, ultimately a constructed confidence interval is our best guess of an interval that contains the population parameter. In other words, it's our best net.
 
-So returning to our pennies example and focusing on the percentile method, we are 95% "confident" that the true mean year of pennies in circulation in 2019 is somewhere between `r percentile_ci[["2.5%"]] %>% round(2)` and `r percentile_ci[["97.5%"]] %>% round(2)`.
+So returning to our pennies example and focusing on the percentile method, we are 95% "confident" that the true mean year of pennies in circulation in 2019 is somewhere between `r percentile_ci[["lower_ci"]] %>% round(2)` and `r percentile_ci[["upper_ci"]] %>% round(2)`.
 
 
 ### Width of confidence intervals {#ci-width}
@@ -1995,7 +1995,7 @@ visualize(bootstrap_distribution_yawning) +
 
 ### Interpreting the confidence interval
 
-Given that both confidence intervals are quite similar, let's focus our interpretation to only the percentile-method confidence interval of (`r myth_ci_percentile[["2.5%"]] %>% round(4)`, `r myth_ci_percentile[["97.5%"]] %>% round(4)`). Recall from Subsection \@ref(shorthand) that the precise statistical interpretation of a 95% confidence interval is: if this construction procedure is repeated 100 times, then we expect about 95 of the confidence intervals to capture the true value of $p_{seed} - p_{control}$. In other words, if we gathered 100 samples of $n$ = `r n_participants` participants from a similar pool of people and constructed 100 confidence intervals each based on each of the 100 samples, about 95 of them will contain the true value of $p_{seed} - p_{control}$ while about five won't. Given that this is a little long winded, we use the shorthand interpretation: we're 95% "confident" that the true difference in proportions $p_{seed} - p_{control}$ is between (`r myth_ci_percentile[["2.5%"]] %>% round(4)`, `r myth_ci_percentile[["97.5%"]] %>% round(4)`).
+Given that both confidence intervals are quite similar, let's focus our interpretation to only the percentile-method confidence interval of (`r myth_ci_percentile[["lower_ci"]] %>% round(4)`, `r myth_ci_percentile[["upper_ci"]] %>% round(4)`). Recall from Subsection \@ref(shorthand) that the precise statistical interpretation of a 95% confidence interval is: if this construction procedure is repeated 100 times, then we expect about 95 of the confidence intervals to capture the true value of $p_{seed} - p_{control}$. In other words, if we gathered 100 samples of $n$ = `r n_participants` participants from a similar pool of people and constructed 100 confidence intervals each based on each of the 100 samples, about 95 of them will contain the true value of $p_{seed} - p_{control}$ while about five won't. Given that this is a little long winded, we use the shorthand interpretation: we're 95% "confident" that the true difference in proportions $p_{seed} - p_{control}$ is between (`r myth_ci_percentile[["lower_ci"]] %>% round(4)`, `r myth_ci_percentile[["upper_ci"]] %>% round(4)`).
 
 There is one value of particular interest that this 95% confidence interval contains: zero. If $p_{seed} - p_{control}$ were equal to 0, then there would be no difference in proportion yawning between the two groups. This would suggest that there is no associated effect of being exposed to a yawning recruiter on whether you yawn yourself. 
 

--- a/09-hypothesis-testing.Rmd
+++ b/09-hypothesis-testing.Rmd
@@ -767,7 +767,7 @@ percentile_ci <- bootstrap_distribution %>%
 percentile_ci
 ```
 
-Using our shorthand interpretation for 95% confidence intervals from Subsection \@ref(shorthand), we are 95% "confident" that the true difference in population proportions $p_{m} - p_{f}$ is between (`r percentile_ci[["2.5%"]] %>% round(3)`, `r percentile_ci[["97.5%"]] %>% round(3)`). Let's visualize `bootstrap_distribution` and this percentile-based 95% confidence interval for $p_{m} - p_{f}$ in Figure \@ref(fig:bootstrap-distribution-two-prop-percentile).
+Using our shorthand interpretation for 95% confidence intervals from Subsection \@ref(shorthand), we are 95% "confident" that the true difference in population proportions $p_{m} - p_{f}$ is between (`r percentile_ci[["lower_ci"]] %>% round(3)`, `r percentile_ci[["upper_ci"]] %>% round(3)`). Let's visualize `bootstrap_distribution` and this percentile-based 95% confidence interval for $p_{m} - p_{f}$ in Figure \@ref(fig:bootstrap-distribution-two-prop-percentile).
 
 ```{r eval=FALSE}
 visualize(bootstrap_distribution) + 

--- a/92-appendixB.Rmd
+++ b/92-appendixB.Rmd
@@ -225,7 +225,7 @@ boot_distn_one_mean %>%
 
 We see that `r mu0` is not contained in this confidence interval as a plausible value of $\mu$ (the unknown population mean) and the entire interval is larger than `r mu0`.  This matches with our hypothesis test results of rejecting the null hypothesis in favor of the alternative ($\mu > 23$).
 
-**Interpretation**:  We are 95% confident the true mean age of first marriage for all US women from 2006 to 2010 is between `r ci[["2.5%"]]` and `r ci[["97.5%"]]`.
+**Interpretation**:  We are 95% confident the true mean age of first marriage for all US women from 2006 to 2010 is between `r ci[["lower_ci"]]` and `r ci[["upper_ci"]]`.
 
 
 ### Traditional methods
@@ -457,7 +457,7 @@ boot_distn_one_prop %>%
 
 We see that 0.80 is contained in this confidence interval as a plausible value of $\pi$ (the unknown population proportion).  This matches with our hypothesis test results of failing to reject the null hypothesis.
 
-**Interpretation**:  We are 95% confident the true proportion of customers who are satisfied with the service they receive is between `r ci[["2.5%"]]` and `r ci[["97.5%"]]`.
+**Interpretation**:  We are 95% confident the true proportion of customers who are satisfied with the service they receive is between `r ci[["lower_ci"]]` and `r ci[["upper_ci"]]`.
 
 
 ### Traditional methods
@@ -715,7 +715,7 @@ boot_distn_two_props %>%
 
 We see that 0 is not contained in this confidence interval as a plausible value of $\pi_{college} - \pi_{no\_college}$ (the unknown population parameter).  This matches with our hypothesis test results of rejecting the null hypothesis.  Since zero is not a plausible value of the population parameter, we have evidence that the proportion of college graduates in California with no opinion on drilling is different than that of non-college graduates.
 
-**Interpretation**:  We are 95% confident the true proportion of non-college graduates with no opinion on offshore drilling in California is between `r round(-ci[["2.5%"]], 2)` dollars smaller to `r round(-ci[["97.5%"]], 2)` dollars smaller than for college graduates.
+**Interpretation**:  We are 95% confident the true proportion of non-college graduates with no opinion on offshore drilling in California is between `r round(-ci[["lower_ci"]], 2)` dollars smaller to `r round(-ci[["upper_ci"]], 2)` dollars smaller than for college graduates.
 
 
 ### Traditional methods
@@ -996,7 +996,7 @@ boot_distn_two_means %>%
 
 We see that 0 is contained in this confidence interval as a plausible value of $\mu_{sac} - \mu_{cle}$ (the unknown population parameter).  This matches with our hypothesis test results of failing to reject the null hypothesis.  Since zero is a plausible value of the population parameter, we do not have evidence that Sacramento incomes are different than Cleveland incomes.
 
-**Interpretation**:  We are 95% confident the true mean yearly income for those living in Sacramento is between `r round(-ci[["2.5%"]], 2)` dollars smaller to `r round(ci[["97.5%"]], 2)` dollars higher than for Cleveland.
+**Interpretation**:  We are 95% confident the true mean yearly income for those living in Sacramento is between `r round(-ci[["lower_ci"]], 2)` dollars smaller to `r round(ci[["upper_ci"]], 2)` dollars higher than for Cleveland.
 
 **Note**:  You could also use the null distribution based on randomization with a shift to have its center at $\bar{x}_{sac} - \bar{x}_{cle} = \$`r round(d_hat, 2)`$ instead of at 0 and calculate its percentiles.  The confidence interval produced via this method should be comparable to the one done using bootstrapping above.
 
@@ -1260,7 +1260,7 @@ boot_distn_paired_means %>%
 
 We see that 0 is not contained in this confidence interval as a plausible value of $\mu_{diff}$ (the unknown population parameter).  This matches with our hypothesis test results of rejecting the null hypothesis.  Since zero is not a plausible value of the population parameter and since the entire confidence interval falls below zero, we have evidence that surface zinc concentration levels are lower, on average, than bottom level zinc concentrations.
 
-**Interpretation**:  We are 95% confident the true mean zinc concentration on the surface is between `r round(-ci[["2.5%"]], 2)` units smaller to `r round(-ci[["97.5%"]], 2)` units smaller than on the bottom.
+**Interpretation**:  We are 95% confident the true mean zinc concentration on the surface is between `r round(-ci[["lower_ci"]], 2)` units smaller to `r round(-ci[["upper_ci"]], 2)` units smaller than on the bottom.
 
 
 ### Traditional methods

--- a/bib/packages.bib
+++ b/bib/packages.bib
@@ -98,9 +98,9 @@ https://infer.netlify.com/},
 @Manual{R-moderndive,
   title = {moderndive: Tidyverse-Friendly Introductory Linear Regression},
   author = {Albert Y. Kim and Chester Ismay},
-  note = {R package version 0.5.0.9000},
-  url = {https://github.com/ModernDive/moderndive_package},
   year = {2020},
+  note = {R package version 0.5.0},
+  url = {https://CRAN.R-project.org/package=moderndive},
 }
 
 @Manual{R-nycflights13,

--- a/bib/packages.bib
+++ b/bib/packages.bib
@@ -16,10 +16,10 @@
 }
 
 @Manual{R-broom,
-  title = {broom: Convert Statistical Analysis Objects into Tidy Tibbles},
-  author = {David Robinson and Alex Hayes},
+  title = {broom: Convert Statistical Objects into Tidy Tibbles},
+  author = {David Robinson and Alex Hayes and Simon Couch},
   year = {2020},
-  note = {R package version 0.5.6},
+  note = {R package version 0.7.0},
   url = {https://CRAN.R-project.org/package=broom},
 }
 
@@ -27,7 +27,7 @@
   title = {dplyr: A Grammar of Data Manipulation},
   author = {Hadley Wickham and Romain François and Lionel Henry and Kirill Müller},
   year = {2020},
-  note = {R package version 1.0.0},
+  note = {R package version 1.0.1},
   url = {https://CRAN.R-project.org/package=dplyr},
 }
 
@@ -40,12 +40,11 @@
 }
 
 @Manual{R-fivethirtyeight,
-  title = {fivethirtyeight: Data and Code Behind the Stories and Interactives at
-'FiveThirtyEight'},
+  title = {fivethirtyeight: Data and Code Behind the Stories and Interactives at 'FiveThirtyEight'},
   author = {Albert Y. Kim and Chester Ismay and Jennifer Chunn},
-  year = {2019},
-  note = {R package version 0.5.0},
-  url = {https://CRAN.R-project.org/package=fivethirtyeight},
+  note = {R package version 0.6.1},
+  url = {https://github.com/rudeboybert/fivethirtyeight},
+  year = {2020},
 }
 
 @Manual{R-ggplot2,
@@ -67,9 +66,9 @@
 @Manual{R-infer,
   title = {infer: Tidy Statistical Inference},
   author = {Andrew Bray and Chester Ismay and Evgeni Chasnovski and Ben Baumer and Mine Cetinkaya-Rundel},
+  note = {https://github.com/tidymodels/infer,
+https://infer.netlify.com/},
   year = {2020},
-  note = {R package version 0.5.2},
-  url = {https://CRAN.R-project.org/package=infer},
 }
 
 @Manual{R-janitor,
@@ -99,7 +98,7 @@
 @Manual{R-moderndive,
   title = {moderndive: Tidyverse-Friendly Introductory Linear Regression},
   author = {Albert Y. Kim and Chester Ismay},
-  note = {R package version 0.5.0},
+  note = {R package version 0.5.0.9000},
   url = {https://github.com/ModernDive/moderndive_package},
   year = {2020},
 }
@@ -132,7 +131,7 @@
   title = {skimr: Compact and Flexible Summaries of Data},
   author = {Elin Waring and Michael Quinn and Amelia McNamara and Eduardo {Arino de la Rubia} and Hao Zhu and Shannon Ellis},
   year = {2020},
-  note = {R package version 2.1.1},
+  note = {R package version 2.1.2},
   url = {https://CRAN.R-project.org/package=skimr},
 }
 
@@ -140,7 +139,7 @@
   title = {tibble: Simple Data Frames},
   author = {Kirill Müller and Hadley Wickham},
   year = {2020},
-  note = {R package version 3.0.2},
+  note = {R package version 3.0.3},
   url = {https://CRAN.R-project.org/package=tibble},
 }
 
@@ -148,7 +147,7 @@
   title = {tidyr: Tidy Messy Data},
   author = {Hadley Wickham and Lionel Henry},
   year = {2020},
-  note = {R package version 1.1.0},
+  note = {R package version 1.1.1},
   url = {https://CRAN.R-project.org/package=tidyr},
 }
 


### PR DESCRIPTION
Fixed:
* Much like with "Conclusion" references, there were ambiguous "Related Topics" references. 
* As of [`infer` v0.5.3](https://github.com/tidymodels/infer/releases/tag/v0.5.3), all confidence intervals have standardized `lower_ci` & `upper_ci` variable names. For example for 95% percentile-based bootstrap confidence intervals, the end points are no longer referred with `[["2.5%"]]` and `[["97.5%"]]`
* Local hosting of interactive 3D scatterplot & regression plane. You can test a demo [here](https://moderndive.github.io/moderndive_labs/3D_scatterplot_plane.html). Lemme know if you think it's too choppy b/c of latency