### PR TITLE
Update 94-appendixD.Rmd - LC9.8 and LC9.11

### DIFF
--- a/94-appendixD.Rmd
+++ b/94-appendixD.Rmd
@@ -1459,7 +1459,7 @@ The p-value's 0.05 threshold can be misleading researchers to conduct multiple b
 
 **Solution**:  
 
-The greater $\alpha$ of 0.1 will lead to a more liberal hypothesis testing procedure, because the required p-value to reject the null hypothesis $H_0$ is greater. There is a higher chance that the p-value will be less than $\alpha$
+The greater $\alpha$ of 0.1 will lead to a more liberal hypothesis testing procedure, because the required p-value to reject the null hypothesis $H_0$ can be greater. There is a higher chance that the p-value will be less than $\alpha$
 
 **`r paste0("(LC", chap, ".", (lc <- lc + 1), ")")`** Conduct the same analysis comparing action movies versus romantic movies using the median rating instead of the mean rating. What was different and what was the same? 
 

--- a/94-appendixD.Rmd
+++ b/94-appendixD.Rmd
@@ -1459,7 +1459,7 @@ The p-value's 0.05 threshold can be misleading researchers to conduct multiple b
 
 **Solution**:  
 
-The smaller $\alpha$ of 0.01 will lead to a more liberal hypothesis testing procedure, because the required p-value for reject the null hypothesis $H_0$ is smaller. 
+The greater $\alpha$ of 0.1 will lead to a more liberal hypothesis testing procedure, because the required p-value to reject the null hypothesis $H_0$ is greater. There is a higher chance that the p-value will be less than $\alpha$
 
 **`r paste0("(LC", chap, ".", (lc <- lc + 1), ")")`** Conduct the same analysis comparing action movies versus romantic movies using the median rating instead of the mean rating. What was different and what was the same? 
 
@@ -1479,7 +1479,7 @@ From the faceted histogram, we can also see the comparison of rating` versus `ge
 
 **Solution**:  
 
-We use the `movies_sample` dataset as the input for test statistic. The $H_0$ model is "there is no statistical difference existed between mean movie ratings for action and romance movies", and with the p-value from `infer` commands, we reject the $H_0$ model and conclude that there is a statistical difference existed between mean movie ratings for action and romance movies.
+We use the `movies_sample` dataset as the input for test statistic. The $H_0$ model is "there is no statistical difference existed between mean movie ratings for action and romance movies", and with the p-value from `infer` commands, we fail to reject the $H_0$ model and conclude that there is insufficient evidence to conclude that a statistical difference existed between mean movie ratings for action and romance movies.
 
 **`r paste0("(LC", chap, ".", (lc <- lc + 1), ")")`** Why are we relatively confident that the distributions of the sample ratings will be good approximations of the population distributions of ratings for the two genres?
 


### PR DESCRIPTION
LC9.8 - The larger significance level would lead to a more liberal hypothesis, not the smaller

LC9.11 - In chapter 9.5 we failed to reject the null hypothesis because the p-value of 0.004 was greater than our significance level of 0.001. Fixing the solution so it's in line with this.