### PR TITLE
Update 08-confidence-intervals.Rmd

### DIFF
--- a/08-confidence-intervals.Rmd
+++ b/08-confidence-intervals.Rmd
@@ -43,7 +43,7 @@ In Chapter \@ref(sampling), we studied sampling. We started with a "tactile" exe
 n_virtual_resample <- 1000L
 ```
 
-We then mimicked this "tactile" sampling exercise with an equivalent "virtual" sampling exercise performed on the computer. Using our computer's random number generator, we quickly mimicked the above sampling procedure a large number of times. In Subsection \@ref(different-shovels), we quickly repeated this sampling procedure `r n_virtual_resample` times, using three different "virtual" shovels with 25, 50, and 100 slots. We visualized these three sets of `r n_virtual_resample` estimates in Figure \@ref(fig:comparing-sampling-distributions-3) and saw that as the sample size increased, the variation in the estimates decreased.
+We then mimicked this "tactile" sampling exercise with an equivalent "virtual" sampling exercise performed on the computer. Using our computer's random number generator, we quickly mimicked the above sampling procedure a large number of times. In Subsection \@ref(sampling-simulation), we quickly repeated this sampling procedure `r n_virtual_resample` times, using three different "virtual" shovels with 25, 50, and 100 slots. We visualized these three sets of `r n_virtual_resample` estimates in Figure \@ref(fig:comparing-sampling-distributions-3) and saw that as the sample size increased, the variation in the estimates decreased.
 
 In doing so, what we did was construct *sampling distributions*. The motivation for taking `r n_virtual_resample` repeated samples and visualizing the resulting estimates was to study how these estimates varied from one sample to another; in other words, we wanted to study the effect of *sampling variation*. We quantified the variation of these estimates using their standard deviation, which has a special name: the *standard error*. In particular, we saw that as the sample size increased from 25 to 50 to 100, the standard error decreased and thus the sampling distributions narrowed. Larger sample sizes led to more *precise* estimates that varied less around the center. 
 
@@ -1581,7 +1581,7 @@ percentile_cis_by_level %>%
 
 So in order to have a higher confidence level, our confidence intervals must be wider. Ideally, we would have both a high confidence level and narrow confidence intervals. However, we cannot have it both ways. If we want to _be more confident_, we need to allow for wider intervals. Conversely, if we would like a narrow interval, we must tolerate a lower confidence level. 
 
-The moral of the story is: \index{confidence interval!impact of confidence level on interval width} **Higher confidence levels tend to produce wider confidence intervals.**  When looking at Figure \@ref(fig:reliable-percentile-80-95-99) it is important to keep in mind that we kept the sample size fixed at $n$ = `r n_balls_sample`. Thus, all $10 \cdot 3 = 30$ random samples from the `bowl` had the same sample size. What happens if instead we took samples of different sizes? Recall that we did this in Subsection \@ref(different-shovels) using virtual shovels with 25, 50, and 100 slots. <!-- We delve into this next. -->
+The moral of the story is: \index{confidence interval!impact of confidence level on interval width} **Higher confidence levels tend to produce wider confidence intervals.**  When looking at Figure \@ref(fig:reliable-percentile-80-95-99) it is important to keep in mind that we kept the sample size fixed at $n$ = `r n_balls_sample`. Thus, all $10 \cdot 3 = 30$ random samples from the `bowl` had the same sample size. What happens if instead we took samples of different sizes? Recall that we did this in Subsection \@ref(sampling-simulation) using virtual shovels with 25, 50, and 100 slots. <!-- We delve into this next. -->
 
 #### Impact of sample size {-}
 
@@ -2027,7 +2027,7 @@ statement.
 
 Let's talk more about the relationship between *sampling distributions* and *bootstrap distributions*.\index{bootstrap!distribution}\index{sampling distributions}
 
-Recall back in Subsection \@ref(shovel-1000-times), we took `r n_virtual_resample` virtual samples from the `bowl` using a virtual shovel, computed `r n_virtual_resample` values of the sample proportion red $\widehat{p}$, then visualized their distribution in a histogram. Recall that this distribution is called the *sampling distribution of* $\widehat{p}$. Furthermore, the standard deviation of the sampling distribution has a special name: the *standard error*.
+Recall back in Subsection \@ref(sampling-simulation), we took `r n_virtual_resample` virtual samples from the `bowl` using a virtual shovel, computed `r n_virtual_resample` values of the sample proportion red $\widehat{p}$, then visualized their distribution in a histogram. Recall that this distribution is called the *sampling distribution of* $\widehat{p}$. Furthermore, the standard deviation of the sampling distribution has a special name: the *standard error*.
 
 We also mentioned that this sampling activity does not reflect how sampling is done in real life. Rather, it was an *idealized version* of sampling so that we could study the effects of sampling variation on estimates, like the proportion of the shovel's balls that are red. In real life, however, one would take a single sample that's as large as possible, much like in the Obama poll we saw in Section \@ref(sampling-case-study). But how can we get a sense of the effect of sampling variation on estimates if we only have one sample and thus only one estimate? Don't we need many samples and hence many estimates?
 
@@ -2037,13 +2037,13 @@ This distribution was called the *bootstrap distribution* of $\overline{x}$. We 
 
 Let's show you that this is the case by now comparing these two types of distributions. Specifically, we'll compare
 
-1. the sampling distribution of $\widehat{p}$ based on `r n_virtual_resample` virtual samples from the `bowl` from Subsection \@ref(shovel-1000-times) to
+1. the sampling distribution of $\widehat{p}$ based on `r n_virtual_resample` virtual samples from the `bowl` from Subsection \@ref(sampling-simulation) to
 1. the bootstrap distribution of $\widehat{p}$ based on `r n_virtual_resample` virtual resamples with replacement from Ilyas and Yohan's single sample `bowl_sample_1` from Subsection \@ref(ilyas-yohan).
 
 
 #### Sampling distribution {-}
 
-Here is the code you saw in Subsection \@ref(shovel-1000-times) to construct the sampling distribution of $\widehat{p}$ shown again in Figure \@ref(fig:sampling-distribution-part-deux), with some changes to incorporate the statistical terminology relating to sampling from Subsection \@ref(terminology-and-notation).
+Here is the code you saw in Subsection \@ref(sampling-simulation) to construct the sampling distribution of $\widehat{p}$ shown again in Figure \@ref(fig:sampling-distribution-part-deux), with some changes to incorporate the statistical terminology relating to sampling from Subsection \@ref(terminology-and-notation).
 
 ```{r,echo=FALSE}
 set.seed(76)


### PR DESCRIPTION
There are references to section 7.2, subsection 7.2.1 for the virtual sampling 1000x that show up as ?? in the published version in ch 8. I *think* the ref location is "sampling-simulation".