### PR TITLE
Correct plots in Appendix B

### DIFF
--- a/92-appendixB.Rmd
+++ b/92-appendixB.Rmd
@@ -177,7 +177,8 @@ We can next use this distribution to observe our $p$-value.  Recall this is a ri
 
 ```{r}
 null_distn_one_mean %>%
-  visualize(obs_stat = x_bar, direction = "greater")
+  visualize() +
+  shade_p_value(obs_stat = x_bar, direction = "greater")
 ```
 
 ##### Calculate $p$-value {-}
@@ -220,7 +221,8 @@ ci
 
 ```{r}
 boot_distn_one_mean %>%
-  visualize(endpoints = ci, direction = "between")
+  visualize() +
+  shade_ci(endpoints = ci)
 ```
 
 We see that `r mu0` is not contained in this confidence interval as a plausible value of $\mu$ (the unknown population mean) and the entire interval is larger than `r mu0`.  This matches with our hypothesis test results of rejecting the null hypothesis in favor of the alternative ($\mu > 23$).
@@ -401,7 +403,8 @@ We can next use this distribution to observe our $p$-value.  Recall this is a tw
 
 ```{r}
 null_distn_one_prop %>%
-  visualize(obs_stat = p_hat, direction = "both")
+  visualize() +
+  shade_p_value(obs_stat = p_hat, direction = "both")
 ```
 
 ##### Calculate $p$-value {-}
@@ -452,7 +455,8 @@ ci
 
 ```{r}
 boot_distn_one_prop %>%
-  visualize(endpoints = ci, direction = "between")
+  visualize() +
+  shade_ci(endpoints = ci)
 ```
 
 We see that 0.80 is contained in this confidence interval as a plausible value of $\pi$ (the unknown population proportion).  This matches with our hypothesis test results of failing to reject the null hypothesis.
@@ -499,8 +503,9 @@ We see here that the $z_{obs}$ value is around `r z_obs`. Our observed sample pr
 elec %>%
   specify(response = satisfy, success = "satisfied") %>%
   hypothesize(null = "point", p = 0.8) %>%
-  calculate(stat = "z") %>%
-  visualize(method = "theoretical", obs_stat = z_obs, direction = "both")
+  assume(distribution = "z") %>%
+  visualize() +
+  shade_p_value(obs_stat = z_obs, direction = "both")
 2 * pnorm(z_obs)
 ```
 
@@ -667,7 +672,8 @@ We can next use this distribution to observe our $p$-value.  Recall this is a tw
 
 ```{r}
 null_distn_two_props %>%
-  visualize(obs_stat = d_hat, direction = "two_sided")
+  visualize() +
+  shade_p_value(obs_stat = d_hat, direction = "both")
 ```
 
 ##### Calculate $p$-value {-}
@@ -710,7 +716,8 @@ ci
 
 ```{r}
 boot_distn_two_props %>%
-  visualize(endpoints = ci, direction = "between")
+  visualize() +
+  shade_ci(endpoints = ci)
 ```
 
 We see that 0 is not contained in this confidence interval as a plausible value of $\pi_{college} - \pi_{no\_college}$ (the unknown population parameter).  This matches with our hypothesis test results of rejecting the null hypothesis.  Since zero is not a plausible value of the population parameter, we have evidence that the proportion of college graduates in California with no opinion on drilling is different than that of non-college graduates.
@@ -865,7 +872,7 @@ The boxplot below also shows the mean for each group highlighted by the red dots
 ```{r boxplot}
 ggplot(cle_sac, aes(x = metro_area, y = income)) +
   geom_boxplot() +
-  stat_summary(fun.y = "mean", geom = "point", color = "red")
+  stat_summary(fun = "mean", geom = "point", color = "red")
 ```
 
 #### Guess about statistical significance {-}
@@ -940,7 +947,8 @@ We can next use this distribution to observe our $p$-value.  Recall this is a tw
 
 ```{r}
 null_distn_two_means %>%
-  visualize(obs_stat = d_hat, direction = "both")
+  visualize() +
+  shade_p_value(obs_stat = d_hat, direction = "both")
 ```
 
 ##### Calculate $p$-value {-}
@@ -989,7 +997,8 @@ ci
 
 ```{r}
 boot_distn_two_means %>%
-  visualize(endpoints = ci, direction = "between")
+  visualize() +
+  shade_ci(endpoints = ci)
 ```
 
 We see that 0 is contained in this confidence interval as a plausible value of $\mu_{sac} - \mu_{cle}$ (the unknown population parameter).  This matches with our hypothesis test results of failing to reject the null hypothesis.  Since zero is a plausible value of the population parameter, we do not have evidence that Sacramento incomes are different than Cleveland incomes.
@@ -1208,7 +1217,8 @@ We can next use this distribution to observe our $p$-value.  Recall this is a le
 
 ```{r}
 null_distn_paired_means %>%
-  visualize(obs_stat = d_hat, direction = "less")
+  visualize() +
+  shade_p_value(obs_stat = d_hat, direction = "less")
 ```
 
 ##### Calculate $p$-value {-}
@@ -1252,7 +1262,8 @@ ci
 
 ```{r}
 boot_distn_paired_means %>%
-  visualize(endpoints = ci, direction = "between")
+  visualize() +
+  shade_ci(endpoints = ci)
 ```
 
 We see that 0 is not contained in this confidence interval as a plausible value of $\mu_{diff}$ (the unknown population parameter).  This matches with our hypothesis test results of rejecting the null hypothesis.  Since zero is not a plausible value of the population parameter and since the entire confidence interval falls below zero, we have evidence that surface zinc concentration levels are lower, on average, than bottom level zinc concentrations.


### PR DESCRIPTION
Currently some plots in Appendix B fail to show p-value or confidence intervals, due to deprecated arguments.