### PR TITLE
Added missing closing comment

### DIFF
--- a/07-sampling.Rmd
+++ b/07-sampling.Rmd
@@ -233,16 +233,8 @@ fruit_basket <- tibble(
 )
 ```
 
-We'll then `%>%` pipe the `fruit_basket` data frame into the `rep_sample_n()` function and set `size = 3`, indicating that we want to sample three fruit:
+-->
 
-```{r}
-fruit_basket %>% 
-  rep_sample_n(size = 3)
-```
-
-Observe that `bowl` has `r num_balls` rows, telling us that the bowl contains `r num_balls` equally sized balls. The first variable `ball_ID` is used as an *identification variable* as discussed in Subsection \@ref(identification-vs-measurement-variables); none of the balls in the actual bowl are marked with numbers. The second variable `color` indicates whether a particular virtual ball is red or white. View the contents of the bowl in RStudio's data viewer and scroll through the contents to convince yourself that `bowl` is indeed a virtual analog of the actual bowl in Figure \@ref(fig:sampling-exercise-1).
-
-Now that we have a virtual analog of our bowl, we now need a virtual analog to the shovel seen in Figure \@ref(fig:sampling-exercise-2) to generate virtual samples of 50 balls. We're going to use the `rep_sample_n()` function included in the `moderndive` package. This function allows us to take `rep`eated, or `rep`licated, `samples` of size `n`. 
 
 ```{r}
 virtual_shovel <- bowl %>% 


### PR DESCRIPTION
Oh damn, during our massive v2 major edits in #418 it seems we forgot to close an HTML `<!--`. As a result, two whole subsections got commented out until the next `-->` occurred:

- 7.2.1 Using the virtual shovel once: [there as it should be currently on moderndive.com](7.2.3 Using the virtual shovel 1000 times)
- 7.2.2 Using the virtual shovel 33 times: missing
- 7.2.3 Using the virtual shovel 1000 times: missing

This is further confirmed by missing LC 7.3 thru 7.5. This PR will put those subsections back and also close #462