### PR TITLE
Update quote attribution to be consistent

### DIFF
--- a/00-preface.Rmd
+++ b/00-preface.Rmd
@@ -122,7 +122,7 @@ Copying and pasting results from one program into a word processor is not an ide
 
 In traditional analyses, if an error was made with the original data, we'd need to step through the entire process again:  recreate the plots and copy-and-paste all of the new plots and our statistical analysis into our document. This is error prone and a frustrating use of time. We want to help you to get away from this tedious activity so that we can spend more time doing science.
 
-> We are talking about _computational_ reproducibility. - Yihui Xie
+> We are talking about _computational_ reproducibility. – Yihui Xie
 
 \index{Xie, Yihui}
 


### PR DESCRIPTION
Update the preface to use em dashes for all quote attributions instead of mixed dashes. I did not find any attributed quotes elsewhere in the book, so this fix should make all quotes rendered consistently throughout.