### PR TITLE
Update 08-confidence-intervals.Rmd

### DIFF
--- a/08-confidence-intervals.Rmd
+++ b/08-confidence-intervals.Rmd
@@ -615,7 +615,7 @@ $$
 \begin{aligned}
 \overline{x} \pm `r qnorm(0.975) %>% round(2)` \cdot SE &= (\overline{x} - `r qnorm(0.975) %>% round(2)` \cdot SE, \overline{x} + `r qnorm(0.975) %>% round(2)` \cdot SE)\\
 &= (`r x_bar %>% pull(mean_year) %>% round(2)` - `r qnorm(0.975) %>% round(2)` \cdot `r bootstrap_se %>% round(2)`, `r x_bar %>% pull(mean_year) %>% round(2)` + `r qnorm(0.975) %>% round(2)` \cdot `r bootstrap_se %>% round(2)`)\\
-&= (1991.15, 1999.73)
+&= (1991.22, 1999.66)
 \end{aligned}
 $$
 


### PR DESCRIPTION
confidence interval calculation corrected.

(but, 1991.22 value must be 1991.23.  If you change it to 1991.23, it will be incompatible with the codes located just below the Figure 8.17).