### PR TITLE
Update 94-appendixD.Rmd

### DIFF
--- a/94-appendixD.Rmd
+++ b/94-appendixD.Rmd
@@ -1500,7 +1500,7 @@ null_distribution_movies_median %>%
 
 **Solution**:  
 
-From the faceted histogram, we can also see the comparison of `rating` versus `genre` over each year, but we cannot conclude them from the boxplot. 
+From the faceted histogram, we can also see the comparison of `rating` versus `genre` over each rating range, but we cannot conclude them from the boxplot. 
 
 **`r paste0("(LC", chap, ".", (lc <- lc + 1), ")")`** Describe in a paragraph how we used Allen Downey's diagram to conclude if a statistical difference existed between mean movie ratings for action and romance movies.
 


### PR DESCRIPTION
Corrected the answer to LC9.10 - with 38 years in `movies_sample`, it is impractical to compare over each year using a 2 * 38 `facet_grid()` plot. I therefore think it should be only faceted by `genre`, which only allows comparison over each rating range.