### PR TITLE
Ch3: fix Envoy/Alaska mixup in pipe-operator example

### DIFF
--- a/03-wrangling.qmd
+++ b/03-wrangling.qmd
@@ -60,7 +60,7 @@ We created these visualizations using the grammar of graphics, which maps variab
 
 In this chapter, we'll introduce a series of functions from the `dplyr` package for data wrangling that will allow you to take a data frame and "wrangle" it (transform it) to suit your needs. Such functions include:
 
-1. `filter()` a data frame's existing rows to only pick out a subset of them. For example, the `alaska_flights` data frame.
+1. `filter()` a data frame's existing rows to only pick out a subset of them. For example, the `envoy_flights` data frame.
 1. `summarize()` one or more of its columns/variables with a *summary statistic*. Examples of summary statistics include the median and interquartile range of temperatures as we saw in @sec-boxplots on boxplots. 
 1. `group_by()` its rows. In other words, assign different rows to be part of the same *group*. We can then combine `group_by()` with `summarize()` to report summary statistics for each group *separately*. For example, say you don't want a single overall average departure delay `dep_delay` for all three `origin` airports combined, but rather three separate average departure delays, one computed for each of the three `origin` airports.
 1. `mutate()` its existing columns/variables to create new ones. For example, convert hourly temperature readings from Fahrenheit to Celsius.
@@ -133,18 +133,18 @@ So while both approaches achieve the same goal, the latter is much more human-re
 
 1. The starting value `x` will be a data frame. For example, the \index{R packages!nycflights23} `flights` data frame we explored in @sec-nycflights.
 1. The sequence of functions, here `f()`, `g()`, and `h()`, will mostly be a sequence of any number of the six data-wrangling verb-named functions we listed in the introduction to this chapter. For example, the `filter(carrier == "MQ")` function and argument specified we previewed earlier.
-1. The result will be the transformed/modified data frame that you want. In our example, we'll save the result in a new data frame by using the `<-` assignment operator with the name `alaska_flights` via `alaska_flights <-`.
+1. The result will be the transformed/modified data frame that you want. In our example, we'll save the result in a new data frame by using the `<-` assignment operator with the name `envoy_flights` via `envoy_flights <-`.
 
-```{r wrangling-filter-alaska, eval=FALSE}
+```{r wrangling-filter-envoy, eval=FALSE}
 envoy_flights <- flights |>
-  filter(carrier == "AS")
+  filter(carrier == "MQ")
 ```
 
 ::: {.callout-tip collapse="true" title="Try it interactively"}
 ```{webr-r}
-alaska_flights <- flights |>
-  filter(carrier == "AS")
-alaska_flights
+envoy_flights <- flights |>
+  filter(carrier == "MQ")
+envoy_flights
 ```
 :::
 


### PR DESCRIPTION
Section 3.1's worked example is meant to continue Ch2's `envoy_flights` preview — the preceding line even cites `filter(carrier == "MQ")` "we previewed earlier" — but the surrounding code and narration had Envoy and Alaska crossed:

- the chapter-intro bullet (line 63) said "the `alaska_flights` data frame"
- the result narration (line 136) said the output is saved as `alaska_flights <-`
- the visible chunk assigned `envoy_flights <- flights |> filter(carrier == "AS")` — Envoy's name with Alaska's carrier code
- the webr chunk built `alaska_flights` with `"AS"`

This PR aligns all four on `envoy_flights` / `"MQ"` (Envoy Air) and renames the chunk label `wrangling-filter-alaska` → `wrangling-filter-envoy`.

Found during a cross-check of the instructor resources against the book source. (The Ch5 Quick-check `lm(life_exp ~ fert_rate)` reversal noted in the same audit is deliberately left out — Quick checks are under separate review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)