### PR TITLE
Exercises: fix four webr scaffolds that contradict their prompts or keys

### DIFF
--- a/exercises/08.yml
+++ b/exercises/08.yml
@@ -9,7 +9,7 @@ exercises:
   difficulty: 1
   group: Theory-based CIs
   webr: |-
-    set.seed(76)
+    set.seed(2)   # the n = 50 sample the rest of this chapter reuses (see EX 8.44)
     # your code here
   prompt: 'Take a single random sample of $n = 50$ from `volcanoes`. Compute $\bar{x}$,
     $s$, and a **theory-based 95% t-CI** for the mean `elevation`. Hint: `xbar ± qt(0.975,

--- a/exercises/09.yml
+++ b/exercises/09.yml
@@ -427,12 +427,16 @@ exercises:
   difficulty: 3
   group: Extensions
   webr: |-
+    set.seed(76)
     ath <- olympic_athletes |> filter(sport == "Athletics", !is.na(height))
-    # Tiny height difference, but with n in the thousands, it's "significant"
-    tiny <- ath |> mutate(height_perturbed = height + ifelse(sex == "M", 0.05, 0))
+    # Two groups identical in every way, then nudge one by a *tiny* 0.5 cm:
+    # with n in the tens of thousands, even that is "significant"
+    tiny <- ath |>
+      mutate(grp = sample(c("A", "B"), n(), replace = TRUE),
+             height_perturbed = height + if_else(grp == "A", 0.5, 0))
     tiny |>
-      t_test(formula = height_perturbed ~ sex,
-             order = c("M", "F"),
+      t_test(formula = height_perturbed ~ grp,
+             order = c("A", "B"),
              alternative = "two-sided")
   prompt: |-
     **Practical vs statistical significance: a worked example.** The snippet randomly splits the athletes into two groups that are *identical* in every way, then nudges one group's heights up by a *tiny* **0.5 cm** — so that 0.5 cm is the entire true difference between them. Run the test. With $n$ in the thousands, the p-value is essentially zero, *statistically significant*. But 0.5 cm is *not practically significant* — it's smaller than the difference made by wearing socks, and below the precision with which heights are recorded. In a 2-sentence write-up, how would you communicate this result honestly to a non-statistical audience?

--- a/exercises/11.yml
+++ b/exercises/11.yml
@@ -212,9 +212,9 @@ exercises:
     set.seed(76)
     house_sub <- house_prices |>
       filter(!is.na(price), !is.na(sqft_living)) |>
-      slice_sample(n = 200)   # small sample to make overfitting visible
+      slice_sample(n = 2000)   # enough data that low-degree fits win and high degrees overfit
 
-    train_idx <- sample(seq_len(200), 160)
+    train_idx <- sample(seq_len(2000), 1600)
     train <- house_sub[ train_idx, ]
     test  <- house_sub[-train_idx, ]
 
@@ -227,7 +227,7 @@ exercises:
 
     rmses
   prompt: |-
-    **Overfitting demonstration.** Add too many predictors (or too high a polynomial degree) and your model will *memorize* the training data, driving the training RMSE down, while predicting badly on new data. Run the snippet, which fits polynomials of degree 1 through 12 on a small training set and tracks training vs test RMSE at each degree. At what degree does the test RMSE *bottom out*? At what degree does training RMSE keep falling while test RMSE *rises*? That's overfitting in action.
+    **Overfitting demonstration.** Add too many predictors (or too high a polynomial degree) and your model will *memorize* the training data, driving the training RMSE down, while predicting badly on new data. Run the snippet, which fits polynomials of degree 1 through 12 on a training set and tracks training vs test RMSE at each degree. At what degree does the test RMSE *bottom out*? At what degree does training RMSE keep falling while test RMSE *rises*? That's overfitting in action.
   book_section: Extensions
   book_subsection: Extensions
 - ex_num: 17
@@ -236,7 +236,15 @@ exercises:
   group: Extensions
   webr: |-
     set.seed(76)
-    # your exploration here
+    hp <- house_prices |>
+      filter(!is.na(price), !is.na(sqft_living), !is.na(bedrooms))
+    train_idx <- sample(seq_len(nrow(hp)), size = floor(0.8 * nrow(hp)))
+    train <- hp[ train_idx, ]
+    test  <- hp[-train_idx, ]
+
+    m <- lm(log10(price) ~ sqft_living + bedrooms, data = train)
+    c(train_r_squared = summary(m)$r.squared,
+      test_rmse = sqrt(mean((log10(test$price) - predict(m, newdata = test))^2)))
   prompt: |-
     **In-sample $R^2$ vs out-of-sample RMSE.** Training $R^2$ rewards "how much variance does the model explain in the *training* data." Test RMSE rewards "how accurately can the model *predict* new observations." For a published model, *both* are worth reporting, the $R^2$ describes the explanatory fit, the test RMSE describes the predictive accuracy. The snippet reports both. Why is the *test* RMSE (not training RMSE) the right number to use when comparing *predictive* models?
   book_section: Extensions


### PR DESCRIPTION
Part of an overnight instructor-side audit of all 492 exercise solutions (mechanical suite + per-exercise review + adversarial verification of every finding — each item below was confirmed by independently running the code).

**EX8.1 (Ch8):** scaffold seeds `set.seed(76)` but the answer key and the whole chapter ecosystem — including EX8.44's own webr — reuse the `set.seed(2)` n=50 volcano sample. Worse than cosmetic: with seed 76 the t-CI is (581, 1581), which *misses* μ = 1676, so a student following the scaffold gets `contains = FALSE` where EX8.2's key says `TRUE`. Scaffold now seeds 2 with a comment.

**EX9.42 (Ch9):** the snippet nudged heights by **sex** (+0.05 cm), so the t-test picks up the real ~10.5 cm sex gap — the opposite of the 'tiny difference, huge n' lesson. Now builds two random groups identical in every way and nudges one by 0.5 cm (verified: estimate 0.43 cm, p = 2.1e-5, matching the key).

**EX11.16 (Ch11):** with n=200 the overfitting demo doesn't demonstrate overfitting (test RMSE bottoms at degree 7, barely rises); with n=2000 it bottoms at degree 2 then explodes at high degrees, matching the key. Prompt's 'small training set' wording updated.

**EX11.17 (Ch11):** prompt says 'The snippet reports both' but the webr was an empty stub. Added the working 80/20 split snippet (train R² 0.493, test RMSE 0.164, matching the key).

All three YAMLs parse; both new snippets run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)