### PR TITLE
Fix broken author webpage link (rudeboybert.rbind.io SSL cert mismatch)

### DIFF
--- a/00-preface.Rmd
+++ b/00-preface.Rmd
@@ -298,7 +298,7 @@ Chester Ismay           |  Albert Y. Kim | Arturo Valdivia
 **Albert Y.\ Kim** is an Associate Professor of Statistical & Data Sciences at Smith College in Northampton, MA, USA. He completed his PhD in statistics at the University of Washington in 2011. Previously he worked in the Search Ads Metrics Team at Google Inc.\ as well as at Reed, Middlebury, and Amherst Colleges. In addition to his work for *ModernDive*, he is a co-author of the [`resampledata`](https://cran.r-project.org/package=resampledata) and [`SpatialEpi`](https://cran.r-project.org/package=SpatialEpi) R packages. Both Dr. Kim and Dr. Ismay, along with [Jennifer Chunn](https://github.com/jchunn), are co-authors of the [`fivethirtyeight`](https://fivethirtyeight-r.netlify.app/) package of code and datasets published by the data journalism website [FiveThirtyEight.com](https://fivethirtyeight.com/).
 
 <!-- * Email: `albert.ys.kim@gmail.com` -->
-* Webpage: <http://rudeboybert.rbind.io/>
+* Webpage: <https://rudeboybert.github.io/>
 * GitHub: <https://github.com/rudeboybert>
 
 <!-- * X (formerly Twitter): [rudeboybert](https://x.com/rudeboybert) -->

--- a/index.Rmd
+++ b/index.Rmd
@@ -254,7 +254,7 @@ The First Edition of this book is available at https://moderndive.com. You can f
 ```
 
 
-<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a><br />This work by [Chester Ismay](https://chester.rbind.io/), [Albert Y. Kim](https://rudeboybert.rbind.io/), and [Arturo Valdivia](https://avaldivi6.github.io) is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a><br />This work by [Chester Ismay](https://chester.rbind.io/), [Albert Y. Kim](https://rudeboybert.github.io/), and [Arturo Valdivia](https://avaldivi6.github.io) is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.
 
 <a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Deploys by Netlify" /> </a>
 


### PR DESCRIPTION
## Summary

Ran a [lychee](https://github.com/lycheeverse/lychee) external link check across the book source. One **genuinely broken link** turned up in the published book, appearing in two places (bookdown `.Rmd` sources on this branch):

- `index.Rmd` — author byline / license line
- `00-preface.Rmd` — Albert Y. Kim's bio ("Webpage")

Both pointed at `rudeboybert.rbind.io`, whose rbind.io custom domain now serves a Netlify wildcard cert (`*.netlify.app`) that no longer matches the hostname, so the URL fails TLS verification (`curl: (60) SSL: no alternative certificate subject name matches target host name`). Fixed by pointing at the HTTPS-valid canonical `https://rudeboybert.github.io/` — the same domain already used for the SDS192/SDS220 course links elsewhere in this preface.

Companion to #564, which applies the identical fix to the Quarto source on the `v2-quarto-html` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)