### PR TITLE
exoplanetdata + volcanoes on CRAN: install exercise packages from CRAN

### DIFF
--- a/scripts/setup_exercise_packages.R
+++ b/scripts/setup_exercise_packages.R
@@ -15,12 +15,12 @@ EXERCISE_PACKAGES <- list(
     from_github = FALSE
   ),
   exoplanetdata = list(
-    repo        = "moderndive/exoplanetdata",
-    from_github = TRUE
+    repo        = NA_character_,
+    from_github = FALSE
   ),
   volcanoes = list(
-    repo        = "moderndive/volcanoes",
-    from_github = TRUE
+    repo        = NA_character_,
+    from_github = FALSE
   ),
   fivethirtyeight = list(
     repo        = NA_character_,


### PR DESCRIPTION
Follow-up to [moderndive-instructor-resources#1](https://github.com/moderndive/moderndive-instructor-resources/pull/1) (merged today): `exoplanetdata` and `volcanoes` are now on CRAN, so this flips their `from_github` flags to `FALSE` in `scripts/setup_exercise_packages.R` — `install_exercise_packages()` now uses `install.packages()` for them, matching `steves` and `fivethirtyeight`. `repo` is set to `NA_character_` per the convention for CRAN entries.

No other code changes needed (per the header comment in that file). webR is unaffected — it uses the shadow library, watched separately by the new webr-watch workflow (#566).

cc @ismayc

🤖 Generated with [Claude Code](https://claude.com/claude-code)