### PR TITLE
CI: align R pin to 4.6.1, and request noble binaries to match the runner

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -30,13 +30,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
 
       - name: Install audit dependencies
         run: |
           R -q -e 'install.packages(c("stringr", "yaml"),
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
 
       - name: Run cross-reference scans
         run: |
@@ -62,13 +62,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
 
       - name: Install audit dependencies
         run: |
           R -q -e 'install.packages(c("yaml", "stringr"),
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
 
       - name: Lint exercise YAMLs
         run: |
@@ -82,12 +82,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install dependencies
         run: |
           R -q -e 'install.packages("stringr",
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Audit heading hierarchy
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_heading_hierarchy.R
@@ -100,12 +100,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install dependencies
         run: |
           R -q -e 'install.packages("stringr",
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Audit section-number references
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_section_refs.R
@@ -118,12 +118,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install dependencies
         run: |
           R -q -e 'install.packages("stringr",
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Audit Quick check format
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_quick_check_format.R
@@ -136,12 +136,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install dependencies
         run: |
           R -q -e 'install.packages(c("yaml", "stringr"),
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Audit exercise lexicon
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_exercise_lexicon.R
@@ -154,12 +154,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install dependencies
         run: |
           R -q -e 'install.packages("stringr",
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Audit unused images + broken refs
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_unused_images.R
@@ -172,12 +172,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install dependencies
         run: |
           R -q -e 'install.packages("stringr",
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Audit terminology
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_terminology.R
@@ -191,13 +191,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
 
       - name: Install audit dependencies
         run: |
           R -q -e 'install.packages("stringr",
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
 
       - name: Run alt-text audit
         run: |
@@ -267,12 +267,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install audit dependencies
         run: |
           R -q -e 'install.packages(c("stringr", "yaml"),
-                                    repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+                                    repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Run webR symbol audit
         run: |
           sed -i "s|^book <- .*|book <- \"$GITHUB_WORKSPACE\"|" scripts/audit_webr_symbols.R
@@ -285,7 +285,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
       - name: Install CRAN packages used by webR cells
         run: |
@@ -295,7 +295,7 @@ jobs:
             "nycflights23", "fivethirtyeight",
             "patchwork", "infer", "broom", "MASS", "conflicted",
             "janitor", "pwr", "readxl", "steves", "remotes"
-          ), repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")'
+          ), repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")'
       - name: Install GitHub-only companion packages
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.5.2"
+          r-version: "4.6.1"
           use-public-rspm: true
 
       - name: Install system libraries for V8

--- a/.github/workflows/preview-quarto.yml
+++ b/.github/workflows/preview-quarto.yml
@@ -30,7 +30,7 @@ jobs:
       # mismatched R API headers).
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.5.2'
+          r-version: '4.6.1'
           use-public-rspm: true
 
       # Install system libraries for the V8 R package

--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -35,7 +35,7 @@ jobs:
       # mismatched R API headers).
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.5.2'
+          r-version: '4.6.1'
           use-public-rspm: true
 
       # Install system libraries for the V8 R package

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.5.3",
+    "Version": "4.6.1",
     "Repositories": [
       {
         "Name": "CRAN",


### PR DESCRIPTION
Two toolchain corrections that had drifted apart from the rest of the project.

## 1. R pin 4.5.2 → 4.6.1

14 sites across 5 workflows, plus `renv.lock`'s `R.Version`, which recorded **4.5.3** and so disagreed with this repo's own workflows.

Local development runs 4.6.1, and the sibling `exercise-solution-checker`'s pre-push parity guard blocks a snapshot re-pin whenever local and CI disagree. Aligning up rather than pinning local down:

- R 4.6.1 shipped 2026-06-24; the project's pinned P3M snapshot is `noble/2026-07-17`, so binaries exist.
- 4.6.1 is numerically compatible with 4.5.x for this content — the checker's chapters 1, 5 and 7 (pinned under 4.5.x, untouched by the round-4 audit) reproduce exactly under 4.6.1, including Ch 7, the most RNG-sensitive chapter in the book.

Note `renv.lock`'s `R.Version` is **informational** for CI here: the render workflows read the lockfile as a JSON manifest of package *names* (`install.packages(need)`), not via `renv::restore()`. So this bump needs no re-provisioning — worth knowing, since that's usually the expensive part of an R bump.

## 2. Package binaries: `jammy` → `noble`

11 sites in `audits.yml`. Every job runs on `ubuntu-latest`, which is now Ubuntu 24.04 (**noble**), but these jobs requested Ubuntu 22.04 (**jammy**) binaries from P3M — a distro mismatch that at best serves the wrong binaries and at worst silently falls back to source builds. The sibling `moderndive-instructor-resources` already uses `noble` correctly.

Left as `/latest` rather than switching to a dated pin, to keep this change to the distro alone.

## Scope

Toolchain-only; no content changes. Separate from the EX 10.31 prompt fix in #568.

## Must land with

- moderndive/moderndive-instructor-resources (`round4-align-r-4.6.1`)
- moderndive/exercise-solution-checker#6 — same bump, plus the snapshot re-pin it unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fjoesx8nz7uB84RMM57orN